### PR TITLE
Cleanup and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Removes numbering from navigation entries (#16)
 * Navigation, top-level headings and method headings use inline code style (#18, #19)
 
+### Bugfixes
+
+* Generates struct signatures if not present due to seemingly `modo doc` bug (#20)
+* Add underscore at the end of capitalized file names as fix for case-insensitive systems (#20)
+
 ## [[v0.1.1]](https://github.com/mlange-42/modo/compare/v0.1.0...v0.1.1)
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Bugfixes
 
 * Generates struct signatures if not present due to seemingly `modo doc` bug (#20)
-* Add underscore at the end of capitalized file names as fix for case-insensitive systems (#20)
+* Adds underscore at the end of capitalized file names as fix for case-insensitive systems (#20)
 
 ## [[v0.1.1]](https://github.com/mlange-42/modo/compare/v0.1.0...v0.1.1)
 

--- a/cmd/modo/root.go
+++ b/cmd/modo/root.go
@@ -44,7 +44,7 @@ func rootCommand() *cobra.Command {
 
 			rFormat := getFormat(&formats)
 
-			err = modo.RenderPackage(&docs.Decl, outDir, rFormat, true)
+			err = modo.RenderPackage(docs.Decl, outDir, rFormat, true)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/document/document.go
+++ b/document/document.go
@@ -207,7 +207,7 @@ func createSignature(s *Struct) string {
 		b.WriteString(", //")
 	}
 	if prevKind == "pos" {
-		b.WriteString(", //")
+		b.WriteString(", /")
 	}
 
 	b.WriteString("]")

--- a/format/mdbook.go
+++ b/format/mdbook.go
@@ -29,7 +29,7 @@ type summary struct {
 }
 
 func (f *MdBookFormatter) writeSummary(p *document.Package, dir string, t *template.Template) error {
-	summaryPath := path.Join(dir, p.GetName(), "SUMMARY.md")
+	summaryPath := path.Join(dir, p.GetFileName(), "SUMMARY.md")
 
 	s := summary{}
 
@@ -60,7 +60,7 @@ func (f *MdBookFormatter) writeSummary(p *document.Package, dir string, t *templ
 
 func (f *MdBookFormatter) renderPackage(pkg *document.Package, linkPath []string, out *strings.Builder) {
 	newPath := append([]string{}, linkPath...)
-	newPath = append(newPath, pkg.GetName())
+	newPath = append(newPath, pkg.GetFileName())
 	fmt.Fprintf(out, "%-*s- [`%s`](./%s/_index.md))\n", 2*len(linkPath), "", pkg.GetName(), path.Join(newPath...))
 	for _, p := range pkg.Packages {
 		f.renderPackage(p, newPath, out)
@@ -72,18 +72,18 @@ func (f *MdBookFormatter) renderPackage(pkg *document.Package, linkPath []string
 
 func (f *MdBookFormatter) renderModule(mod *document.Module, linkPath []string, out *strings.Builder) {
 	newPath := append([]string{}, linkPath...)
-	newPath = append(newPath, mod.GetName())
+	newPath = append(newPath, mod.GetFileName())
 	pathStr := path.Join(newPath...)
 	fmt.Fprintf(out, "%-*s- [`%s`](./%s/_index.md)\n", 2*len(linkPath), "", mod.GetName(), pathStr)
 
 	for _, s := range mod.Structs {
-		fmt.Fprintf(out, "%-*s- [`%s`](./%s/%s.md)\n", 2*len(linkPath)+2, "", s.GetName(), pathStr, s.GetName())
+		fmt.Fprintf(out, "%-*s- [`%s`](./%s/%s.md)\n", 2*len(linkPath)+2, "", s.GetName(), pathStr, s.GetFileName())
 	}
 	for _, t := range mod.Traits {
-		fmt.Fprintf(out, "%-*s- [`%s`](./%s/%s.md)\n", 2*len(linkPath)+2, "", t.GetName(), pathStr, t.GetName())
+		fmt.Fprintf(out, "%-*s- [`%s`](./%s/%s.md)\n", 2*len(linkPath)+2, "", t.GetName(), pathStr, t.GetFileName())
 	}
 	for _, f := range mod.Functions {
-		fmt.Fprintf(out, "%-*s- [`%s`](./%s/%s.md)\n", 2*len(linkPath)+2, "", f.GetName(), pathStr, f.GetName())
+		fmt.Fprintf(out, "%-*s- [`%s`](./%s/%s.md)\n", 2*len(linkPath)+2, "", f.GetName(), pathStr, f.GetFileName())
 	}
 }
 

--- a/template.go
+++ b/template.go
@@ -35,7 +35,7 @@ func Render(data document.Kinded) (string, error) {
 }
 
 func RenderPackage(p *document.Package, dir string, renderFormat format.Format, root bool) error {
-	pkgPath := path.Join(dir, p.GetName())
+	pkgPath := path.Join(dir, p.GetFileName())
 	if err := mkDirs(pkgPath); err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func RenderPackage(p *document.Package, dir string, renderFormat format.Format, 
 	}
 
 	for _, mod := range p.Modules {
-		modPath := path.Join(pkgPath, mod.GetName())
+		modPath := path.Join(pkgPath, mod.GetFileName())
 		if err := renderModule(mod, modPath); err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func renderList[T interface {
 		if err != nil {
 			return err
 		}
-		strPath := path.Join(dir, elem.GetName())
+		strPath := path.Join(dir, elem.GetFileName())
 		elem.SetPath(strPath)
 		if err := os.WriteFile(strPath+".md", []byte(text), 0666); err != nil {
 			return err

--- a/templates/partial/functions.md
+++ b/templates/partial/functions.md
@@ -2,7 +2,7 @@
 {{if .Functions}}## Functions
 
 {{range .Functions -}}
- - [`{{.GetName}}`]({{.GetName}}.md){{if .Summary}}: {{.Summary}}{{end}}
+ - [`{{.GetName}}`]({{.GetFileName}}.md){{if .Summary}}: {{.Summary}}{{end}}
 {{end -}}
 {{end}}
 {{- end}}

--- a/templates/partial/modules.md
+++ b/templates/partial/modules.md
@@ -2,7 +2,7 @@
 {{if .Modules}}## Modules
 
 {{range .Modules -}}
- - [`{{.GetName}}`]({{.GetName}}/_index.md){{if .Summary}}: {{.Summary}}{{end}}
+ - [`{{.GetName}}`]({{.GetFileName}}/_index.md){{if .Summary}}: {{.Summary}}{{end}}
 {{end -}}
 {{end}}
 {{- end}}

--- a/templates/partial/packages.md
+++ b/templates/partial/packages.md
@@ -2,7 +2,7 @@
 {{if .Packages}}## Packages
 
 {{range .Packages -}}
- - [`{{.GetName}}`]({{.GetName}}/_index.md){{if .Summary}}: {{.Summary}}{{end}}
+ - [`{{.GetName}}`]({{.GetFileName}}/_index.md){{if .Summary}}: {{.Summary}}{{end}}
 {{end -}}
 {{end}}
 {{- end}}

--- a/templates/partial/structs.md
+++ b/templates/partial/structs.md
@@ -2,7 +2,7 @@
 {{if .Structs}}## Structs
 
 {{range .Structs -}}
- - [`{{.GetName}}`]({{.GetName}}.md){{if .Summary}}: {{.Summary}}{{end}}
+ - [`{{.GetName}}`]({{.GetFileName}}.md){{if .Summary}}: {{.Summary}}{{end}}
 {{end -}}
 {{end}}
 {{- end}}

--- a/templates/partial/traits.md
+++ b/templates/partial/traits.md
@@ -2,7 +2,7 @@
 {{if .Traits}}## Traits
 
 {{range .Traits -}}
- - [`{{.GetName}}`]({{.GetName}}.md){{if .Summary}}: {{.Summary}}{{end}}
+ - [`{{.GetName}}`]({{.GetFileName}}.md){{if .Summary}}: {{.Summary}}{{end}}
 {{end -}}
 {{end}}
 {{- end}}


### PR DESCRIPTION
- Hide `__init__` modules
- Generate struct signatures where missing due to `mojo doc` bug modularml/mojo#3938
- Add underscore at the end of capitalized file names as fix for case-insensitive systems

Fixes #13