### PR TITLE
Automatically link source modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [[unpublished]](https://github.com/mlange-42/modo/compare/v0.10.1...main)
 
+### Features
+
+* Modo🧯 can automatically link from doc pages to the containing module's source (#195)
+
 ### Other
 
 * Doc-tests parser supports quadruple backticks (#194)

--- a/assets/config/hugo.mod
+++ b/assets/config/hugo.mod
@@ -1,4 +1,4 @@
-module {{.Module}}
+module {{.GoModule}}
 
 go 1.23.0
 

--- a/assets/config/modo.yaml
+++ b/assets/config/modo.yaml
@@ -15,6 +15,7 @@ source:{{if not .Sources}} []
 {{range .Sources}}  - {{.}}
 {{end}}
 {{end -}}
+# Full URLs of package sources. Used to create source links.
 source-url:{{if not .SourceURLs}} {}
 
 {{else}}

--- a/assets/config/modo.yaml
+++ b/assets/config/modo.yaml
@@ -15,6 +15,12 @@ source:{{if not .Sources}} []
 {{range .Sources}}  - {{.}}
 {{end}}
 {{end -}}
+source-url:{{if not .SourceURLs}} {}
+
+{{else}}
+{{range $key, $value := .SourceURLs}}  {{$key}}: {{$value}}
+{{end}}
+{{end -}}
 # Output directory.
 output: {{if .OutputDir}}{{.OutputDir}}{{else}}docs/{{end}}
 

--- a/assets/templates/function.md
+++ b/assets/templates/function.md
@@ -1,4 +1,4 @@
-Mojo function
+Mojo function [[src]({{sourceUrl}}/{{.Link}})]
 
 # `{{.Name}}`
 

--- a/assets/templates/function.md
+++ b/assets/templates/function.md
@@ -1,4 +1,4 @@
-Mojo function [[src]({{sourceUrl}}/{{.Link}})]
+Mojo function{{template "source_link" .}}
 
 # `{{.Name}}`
 

--- a/assets/templates/module.md
+++ b/assets/templates/module.md
@@ -1,4 +1,4 @@
-Mojo module [[src]({{sourceUrl}}/{{.Link}})]
+Mojo module{{template "source_link" .}}
 
 # `{{.Name}}`
 

--- a/assets/templates/module.md
+++ b/assets/templates/module.md
@@ -1,4 +1,4 @@
-Mojo module
+Mojo module [[src]({{sourceUrl}}/{{.Link}})]
 
 # `{{.Name}}`
 

--- a/assets/templates/package.md
+++ b/assets/templates/package.md
@@ -1,4 +1,4 @@
-Mojo package [[src]({{sourceUrl}}/{{.Link}})]
+Mojo package{{template "source_link" .}}
 
 # `{{.Name}}`
 

--- a/assets/templates/package.md
+++ b/assets/templates/package.md
@@ -1,4 +1,4 @@
-Mojo package
+Mojo package [[src]({{sourceUrl}}/{{.Link}})]
 
 # `{{.Name}}`
 

--- a/assets/templates/partial/source_link.md
+++ b/assets/templates/partial/source_link.md
@@ -1,0 +1,3 @@
+{{define "source_link" -}}
+{{if sourceUrl}} [🡭]({{sourceUrl}}/{{.Link}})
+{{- end}}{{end}}

--- a/assets/templates/struct.md
+++ b/assets/templates/struct.md
@@ -1,4 +1,4 @@
-Mojo struct
+Mojo struct [[src]({{sourceUrl}}/{{.Link}})]
 
 # `{{.Name}}`
 

--- a/assets/templates/struct.md
+++ b/assets/templates/struct.md
@@ -1,4 +1,4 @@
-Mojo struct [[src]({{sourceUrl}}/{{.Link}})]
+Mojo struct{{template "source_link" .}}
 
 # `{{.Name}}`
 

--- a/assets/templates/trait.md
+++ b/assets/templates/trait.md
@@ -1,4 +1,4 @@
-Mojo trait [[src]({{sourceUrl}}/{{.Link}})]
+Mojo trait{{template "source_link" .}}
 
 # `{{.Name}}`
 

--- a/assets/templates/trait.md
+++ b/assets/templates/trait.md
@@ -1,4 +1,4 @@
-Mojo trait
+Mojo trait [[src]({{sourceUrl}}/{{.Link}})]
 
 # `{{.Name}}`
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -204,14 +204,6 @@ func runDir(baseDir string, args *document.Config, form document.Formatter, runF
 	return err
 }
 
-func GetCwdName() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return cwd, err
-	}
-	return filepath.Base(cwd), nil
-}
-
 func commandError(commandType string, err error) error {
 	return fmt.Errorf("in script %s: %s\nTo skip pre- and post-processing scripts, use flag '--bare'", commandType, err)
 }

--- a/docs/docs/src/guide/config.md
+++ b/docs/docs/src/guide/config.md
@@ -94,6 +94,10 @@ input:
 source:
   - src/mypkg
 
+# Full URLs of package sources. Used to create source links.
+source-url:
+  mypkg: https:/github.com/your/project/blob/main/src/mypkg
+
 # Output directory.
 output: docs/site/content
 

--- a/docs/modo.yaml
+++ b/docs/modo.yaml
@@ -2,6 +2,9 @@ input:
   - docs/src/
 source:
   - src/mypkg/
+source-url:
+  mypkg: https://github.com/mlange-42/modo/tree/main/docs/src/mypkg
+
 output: docs/site/content/
 tests: docs/test/
 format: hugo

--- a/document/config.go
+++ b/document/config.go
@@ -3,30 +3,32 @@ package document
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/spf13/viper"
 )
 
 type Config struct {
-	InputFiles      []string `mapstructure:"input" yaml:"input"`
-	Sources         []string `mapstructure:"source" yaml:"source"`
-	OutputDir       string   `mapstructure:"output" yaml:"output"`
-	TestOutput      string   `mapstructure:"tests" yaml:"tests"`
-	RenderFormat    string   `mapstructure:"format" yaml:"format"`
-	UseExports      bool     `mapstructure:"exports" yaml:"exports"`
-	ShortLinks      bool     `mapstructure:"short-links" yaml:"short-links"`
-	ReportMissing   bool     `mapstructure:"report-missing" yaml:"report-missing"`
-	Strict          bool     `mapstructure:"strict" yaml:"strict"`
-	DryRun          bool     `mapstructure:"dry-run" yaml:"dry-run"`
-	CaseInsensitive bool     `mapstructure:"case-insensitive" yaml:"case-insensitive"`
-	Bare            bool     `mapstructure:"bare" yaml:"bare"`
-	TemplateDirs    []string `mapstructure:"templates" yaml:"templates"`
-	PreRun          []string `mapstructure:"pre-run" yaml:"pre-run"`
-	PreBuild        []string `mapstructure:"pre-build" yaml:"pre-build"`
-	PreTest         []string `mapstructure:"pre-test" yaml:"pre-test"`
-	PostTest        []string `mapstructure:"post-test" yaml:"post-test"`
-	PostBuild       []string `mapstructure:"post-build" yaml:"post-build"`
-	PostRun         []string `mapstructure:"post-run" yaml:"post-run"`
+	InputFiles      []string          `mapstructure:"input" yaml:"input"`
+	Sources         []string          `mapstructure:"source" yaml:"source"`
+	SourceURLs      map[string]string `mapstructure:"source-url" yaml:"source-url"`
+	OutputDir       string            `mapstructure:"output" yaml:"output"`
+	TestOutput      string            `mapstructure:"tests" yaml:"tests"`
+	RenderFormat    string            `mapstructure:"format" yaml:"format"`
+	UseExports      bool              `mapstructure:"exports" yaml:"exports"`
+	ShortLinks      bool              `mapstructure:"short-links" yaml:"short-links"`
+	ReportMissing   bool              `mapstructure:"report-missing" yaml:"report-missing"`
+	Strict          bool              `mapstructure:"strict" yaml:"strict"`
+	DryRun          bool              `mapstructure:"dry-run" yaml:"dry-run"`
+	CaseInsensitive bool              `mapstructure:"case-insensitive" yaml:"case-insensitive"`
+	Bare            bool              `mapstructure:"bare" yaml:"bare"`
+	TemplateDirs    []string          `mapstructure:"templates" yaml:"templates"`
+	PreRun          []string          `mapstructure:"pre-run" yaml:"pre-run"`
+	PreBuild        []string          `mapstructure:"pre-build" yaml:"pre-build"`
+	PreTest         []string          `mapstructure:"pre-test" yaml:"pre-test"`
+	PostTest        []string          `mapstructure:"post-test" yaml:"post-test"`
+	PostBuild       []string          `mapstructure:"post-build" yaml:"post-build"`
+	PostRun         []string          `mapstructure:"post-run" yaml:"post-run"`
 }
 
 func ConfigFromViper(v *viper.Viper) (*Config, error) {
@@ -53,7 +55,8 @@ func (c *Config) check(v *viper.Viper) error {
 		}
 	}
 	for _, key := range v.AllKeys() {
-		if _, ok := fields[key]; !ok {
+		parts := strings.Split(key, ".")
+		if _, ok := fields[parts[0]]; !ok {
 			return fmt.Errorf("unknown field '%s' in config file", key)
 		}
 	}

--- a/document/document.go
+++ b/document/document.go
@@ -32,6 +32,7 @@ type Package struct {
 	Structs            []*Struct        `yaml:",omitempty" json:",omitempty"` // Additional field for package re-exports
 	Traits             []*Trait         `yaml:",omitempty" json:",omitempty"` // Additional field for package re-exports
 	exports            []*packageExport `yaml:"-" json:"-"`                   // Additional field for package re-exports
+	MemberLink         `yaml:"-" json:"-"`
 }
 
 func (p *Package) CheckMissing(path string, stats *missingStats) (missing []missingDocs) {
@@ -68,6 +69,7 @@ func (p *Package) linkedCopy() *Package {
 		MemberSummary:     p.MemberSummary,
 		MemberDescription: p.MemberDescription,
 		exports:           p.exports,
+		MemberLink:        p.MemberLink,
 	}
 }
 
@@ -80,6 +82,7 @@ type Module struct {
 	Functions     []*Function
 	Structs       []*Struct
 	Traits        []*Trait
+	MemberLink    `yaml:"-" json:"-"`
 }
 
 func (m *Module) CheckMissing(path string, stats *missingStats) (missing []missingDocs) {
@@ -128,6 +131,7 @@ type Struct struct {
 	Parameters    []*Parameter
 	ParentTraits  []string
 	Signature     string
+	MemberLink    `yaml:"-" json:"-"`
 }
 
 func (s *Struct) CheckMissing(path string, stats *missingStats) (missing []missingDocs) {
@@ -167,6 +171,7 @@ type Function struct {
 	ReturnsDoc           string
 	Signature            string
 	Parameters           []*Parameter
+	MemberLink           `yaml:"-" json:"-"`
 }
 
 func (f *Function) CheckMissing(path string, stats *missingStats) (missing []missingDocs) {
@@ -219,6 +224,7 @@ type Trait struct {
 	Functions     []*Function
 	ParentTraits  []string
 	Deprecated    string
+	MemberLink    `yaml:"-" json:"-"`
 }
 
 func (t *Trait) CheckMissing(path string, stats *missingStats) (missing []missingDocs) {

--- a/document/interface.go
+++ b/document/interface.go
@@ -1,6 +1,7 @@
 package document
 
 import (
+	"path"
 	"unicode"
 )
 
@@ -14,10 +15,6 @@ type missingStats struct {
 	Missing int
 }
 
-//type missingChecker interface {
-//	CheckMissing(path string) (missing []missingDocs)
-//}
-
 type Kinded interface {
 	GetKind() string
 }
@@ -29,6 +26,11 @@ type Named interface {
 
 type Summarized interface {
 	GetSummary() string
+}
+
+type Linked interface {
+	SetLink(path []string, kind string)
+	GetLink() string
 }
 
 type MemberKind struct {
@@ -104,4 +106,20 @@ func isCap(s string) bool {
 	}
 	firstRune := []rune(s)[0]
 	return unicode.IsUpper(firstRune)
+}
+
+type MemberLink struct {
+	Link string
+}
+
+func (m *MemberLink) SetLink(p []string, kind string) {
+	if kind == "package" {
+		m.Link = path.Join(path.Join(p[1:]...), "__init__.mojo")
+	} else {
+		m.Link = path.Join(p[1:]...) + ".mojo"
+	}
+}
+
+func (m *MemberLink) GetLink() string {
+	return m.Link
 }

--- a/document/render.go
+++ b/document/render.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Render(docs *Docs, config *Config, form Formatter, subdir string) error {
-	t, err := LoadTemplates(form, config.TemplateDirs...)
+	t, err := LoadTemplates(form, config.SourceURLs[docs.Decl.Name], config.TemplateDirs...)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func Render(docs *Docs, config *Config, form Formatter, subdir string) error {
 
 func ExtractTests(docs *Docs, config *Config, form Formatter, subdir string) error {
 	caseSensitiveSystem = !config.CaseInsensitive
-	t, err := LoadTemplates(form, config.TemplateDirs...)
+	t, err := LoadTemplates(form, config.SourceURLs[docs.Decl.Name], config.TemplateDirs...)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func ExtractTests(docs *Docs, config *Config, form Formatter, subdir string) err
 func ExtractTestsMarkdown(config *Config, form Formatter, baseDir string, build bool) error {
 	caseSensitiveSystem = !config.CaseInsensitive
 
-	t, err := LoadTemplates(form, config.TemplateDirs...)
+	t, err := LoadTemplates(form, "", config.TemplateDirs...)
 	if err != nil {
 		return err
 	}

--- a/document/render_test.go
+++ b/document/render_test.go
@@ -31,7 +31,7 @@ func TestRenderPackage(tt *testing.T) {
 	}
 
 	form := TestFormatter{}
-	templ, err := LoadTemplates(&form)
+	templ, err := LoadTemplates(&form, "")
 	assert.Nil(tt, err)
 
 	proc := NewProcessor(nil, &form, templ, &Config{})
@@ -64,7 +64,7 @@ func TestRenderModule(tt *testing.T) {
 	}
 
 	form := TestFormatter{}
-	templ, err := LoadTemplates(&form)
+	templ, err := LoadTemplates(&form, "")
 	assert.Nil(tt, err)
 
 	proc := NewProcessor(nil, &form, templ, &Config{})
@@ -265,7 +265,7 @@ decl:
 
 func createProcessor(t *testing.T, docs *Docs, useExports bool, files map[string]string) *Processor {
 	formatter := TestFormatter{}
-	templ, err := LoadTemplates(&formatter)
+	templ, err := LoadTemplates(&formatter, "")
 	assert.Nil(t, err)
 	return NewProcessorWithWriter(docs, &formatter, templ, &Config{UseExports: useExports, ShortLinks: true}, func(file, text string) error {
 		files[file] = text

--- a/document/util.go
+++ b/document/util.go
@@ -49,10 +49,11 @@ func warnOrError(strict bool, pattern string, args ...any) error {
 	return nil
 }
 
-func LoadTemplates(f Formatter, additional ...string) (*template.Template, error) {
+func LoadTemplates(f Formatter, sourceURL string, additional ...string) (*template.Template, error) {
 	templ := template.New("all")
 	templ = templ.Funcs(template.FuncMap{
-		"toLink": f.ToLinkPath,
+		"toLink":    f.ToLinkPath,
+		"sourceUrl": func() string { return sourceURL },
 	})
 	templ, err := templ.ParseFS(assets.Templates, "templates/*.*", "templates/**/*.*")
 	if err != nil {

--- a/document/util_test.go
+++ b/document/util_test.go
@@ -28,3 +28,23 @@ func TestLoadTemplates(t *testing.T) {
 
 	assert.NotNil(t, templ.Lookup("package.md"))
 }
+
+func TestGetGitOrigin(t *testing.T) {
+	conf, err := GetGitOrigin("docs")
+
+	assert.Nil(t, err)
+	assert.Equal(t, conf.Repo, "https://github.com/mlange-42/modo")
+	assert.Equal(t, conf.Title, "modo")
+	assert.Equal(t, conf.Pages, "https://mlange-42.github.io/modo/")
+	assert.Equal(t, conf.GoModule, "github.com/mlange-42/modo/docs")
+}
+
+func TestRepoToTitleAndPages(t *testing.T) {
+	title, pages := repoToTitleAndPages("https://github.com/user/repo")
+	assert.Equal(t, title, "repo")
+	assert.Equal(t, pages, "https://user.github.io/repo/")
+
+	title, pages = repoToTitleAndPages("https://gitlab.com/user/repo")
+	assert.Equal(t, title, "repo")
+	assert.Equal(t, pages, "https://repo.com")
+}

--- a/format/hugo_test.go
+++ b/format/hugo_test.go
@@ -96,23 +96,3 @@ func TestHugoCreateDirs(t *testing.T) {
 		"docs/test",
 	})
 }
-
-func TestGetGitOrigin(t *testing.T) {
-	conf, err := getGitOrigin("docs")
-
-	assert.Nil(t, err)
-	assert.Equal(t, conf.Repo, "https://github.com/mlange-42/modo")
-	assert.Equal(t, conf.Title, "modo")
-	assert.Equal(t, conf.Pages, "https://mlange-42.github.io/modo/")
-	assert.Equal(t, conf.Module, "github.com/mlange-42/modo/docs")
-}
-
-func TestRepoToTitleAndPages(t *testing.T) {
-	title, pages := repoToTitleAndPages("https://github.com/user/repo")
-	assert.Equal(t, title, "repo")
-	assert.Equal(t, pages, "https://user.github.io/repo/")
-
-	title, pages = repoToTitleAndPages("https://gitlab.com/user/repo")
-	assert.Equal(t, title, "repo")
-	assert.Equal(t, pages, "https://repo.com")
-}

--- a/format/hugo_test.go
+++ b/format/hugo_test.go
@@ -36,7 +36,7 @@ func TestHugoToLinkPath(t *testing.T) {
 
 func TestHugoProcessMarkdown(t *testing.T) {
 	form := Hugo{}
-	templ, err := document.LoadTemplates(&form)
+	templ, err := document.LoadTemplates(&form, "")
 	assert.Nil(t, err)
 
 	proc := document.NewProcessor(nil, &form, templ, &document.Config{})

--- a/format/mdbook_test.go
+++ b/format/mdbook_test.go
@@ -110,7 +110,7 @@ func TestMdBookRenderSummary(t *testing.T) {
 		},
 	}
 
-	templ, err := document.LoadTemplates(&f)
+	templ, err := document.LoadTemplates(&f, "")
 	assert.Nil(t, err)
 
 	proc := document.NewProcessor(&docs, &f, templ, &document.Config{})


### PR DESCRIPTION
Fixes #191

As a first trial, the link is put on an arrow next to the line above the title:

![grafik](https://github.com/user-attachments/assets/4cf4b039-bfe1-401f-ad83-ecd78860a9b8)
