### PR TITLE
Inheritance for method docs from parent trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Supports renaming of re-exports like in `from .mod import X as Y` (#189)
 * Adds automatic linking from doc pages to the containing module's source (#195)
 * Adds flag `--config` to all commands, for working with an alternative config file (#202)
+* Struct methods can inherit docs from a parent trait (#208)
 
 ### Bugfixes
 

--- a/docs/docs/src/guide/features/_index.md
+++ b/docs/docs/src/guide/features/_index.md
@@ -11,5 +11,6 @@ Modo🧯's features beyond generating Markdown:
 - [Cross-references](crossrefs) &mdash; Cross-referencing in the API docs.
 - [Re-exports](reexports) &mdash; Restructure package according to re-exports.
 - [Doc-tests](doctests) &mdash; Extract doc tests from code examples in the API docs.
+- [Inheritance](inheritance) &mdash; Inherit method docs from parent traits.
 - [Bash scripts](scripts) &mdash; Configure bash scripts to run before and after processing.
 - [Templates](templates) &mdash; Use templates to customize Modo🧯's output.

--- a/docs/docs/src/guide/features/inheritance.md
+++ b/docs/docs/src/guide/features/inheritance.md
@@ -1,0 +1,45 @@
+---
+title: Inheritance
+type: docs
+summary: Inherit method docs from parent traits.
+weight: 40
+---
+
+When implementing trait methods, documentation of the method
+in the implementing struct is often redundent.
+For these cases, Modo🧯 offers doc inheritance.
+
+In the method docstring, reference the parent trait in curly braces,
+somewhere in the summary (i.e. in the first sentence).
+The syntax is the same as for [cross-references](../crossrefs).
+See line 14 below:
+
+```mojo {doctest="inherit" global=true class="no-wrap" linenos=true}
+trait MyTrait:
+    fn do_something(self) -> Int:
+        """
+        A method that returns an integer.
+
+        Returns:
+            An arbitrary integer.
+        """
+        ...
+
+@value
+struct MyStruct(MyTrait):
+    fn do_something(self) -> Int:
+        """See {.MyTrait}."""
+        return 100
+```
+
+```mojo {doctest="inherit" hide=true}
+var s = MyStruct()
+var result = s.do_something()
+if result != 100:
+    raise Error("failed")
+```
+
+This copies the entire documentation from the trait's method with the same signature into the struct's method. This includes docs for arguments, parameters, return and raises.
+Any original docs of the struct's method are replaced completely.
+
+Inheriting documentation is only possible from traits in the same root package.

--- a/docs/docs/src/guide/features/inheritance.md
+++ b/docs/docs/src/guide/features/inheritance.md
@@ -9,7 +9,7 @@ When implementing trait methods, documentation of the method
 in the implementing struct is often redundent.
 For these cases, Modo🧯 offers doc inheritance.
 
-In the method docstring, reference the parent trait in curly braces,
+In the method docstring, reference the parent trait in double square brackets,
 somewhere in the summary (i.e. in the first sentence).
 The syntax is the same as for [cross-references](../crossrefs).
 See line 14 below:
@@ -28,7 +28,7 @@ trait MyTrait:
 @value
 struct MyStruct(MyTrait):
     fn do_something(self) -> Int:
-        """See {.MyTrait}."""
+        """See [[.MyTrait]]."""
         return 100
 ```
 

--- a/docs/docs/src/guide/features/scripts.md
+++ b/docs/docs/src/guide/features/scripts.md
@@ -2,7 +2,7 @@
 title: Bash scripts
 type: docs
 summary: Configure bash scripts to run before and after processing.
-weight: 40
+weight: 50
 ---
 
 Modo🧯 can be configured to automatically run bash scripts before and/or after processing.

--- a/docs/docs/src/guide/features/templates.md
+++ b/docs/docs/src/guide/features/templates.md
@@ -3,7 +3,7 @@ title: Templates
 type: docs
 summary: Use templates to customize Modo🧯's output.
 next: mypkg
-weight: 50
+weight: 60
 ---
 
 Modo🧯 relies heavily on templating.

--- a/internal/document/links.go
+++ b/internal/document/links.go
@@ -32,7 +32,7 @@ func (proc *Processor) processLinks(docs *Docs) error {
 }
 
 func (proc *Processor) replaceRefs(text string, elems []string, modElems int) (string, error) {
-	indices, err := findLinks(text, linkRegex)
+	indices, err := findLinks(text, linkRegex, true)
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +56,7 @@ func (proc *Processor) replaceRefs(text string, elems []string, modElems int) (s
 }
 
 func (proc *Processor) ReplacePlaceholders(text string, elems []string, modElems int) (string, error) {
-	indices, err := findLinks(text, linkRegex)
+	indices, err := findLinks(text, linkRegex, true)
 	if err != nil {
 		return "", err
 	}
@@ -253,12 +253,12 @@ func (proc *Processor) refToPlaceholderAbs(link string, elems []string, redirect
 	return placeholder, true, nil
 }
 
-func findLinks(text string, regex *regexp.Regexp) ([]int, error) {
+func findLinks(text string, regex *regexp.Regexp, noBracesAfter bool) ([]int, error) {
 	links := []int{}
 	results := regex.FindAllStringSubmatchIndex(text, -1)
 	for _, r := range results {
 		if r[6] >= 0 {
-			if len(text) > r[7] && string(text[r[7]]) == "(" {
+			if noBracesAfter && len(text) > r[7] && string(text[r[7]]) == "(" {
 				continue
 			}
 			links = append(links, r[6], r[7])

--- a/internal/document/links_test.go
+++ b/internal/document/links_test.go
@@ -15,7 +15,7 @@ func TestFindLinks(t *testing.T) {
 		"a [link3] in a code block\n" +
 		"```\n" +
 		"and a normal [link4] again.\n"
-	indices, err := findLinks(text, linkRegex)
+	indices, err := findLinks(text, linkRegex, true)
 	assert.Nil(t, err)
 	assert.NotNil(t, indices)
 	assert.Equal(t, 4, len(indices))

--- a/internal/document/links_test.go
+++ b/internal/document/links_test.go
@@ -15,7 +15,7 @@ func TestFindLinks(t *testing.T) {
 		"a [link3] in a code block\n" +
 		"```\n" +
 		"and a normal [link4] again.\n"
-	indices, err := findLinks(text)
+	indices, err := findLinks(text, linkRegex)
 	assert.Nil(t, err)
 	assert.NotNil(t, indices)
 	assert.Equal(t, 4, len(indices))

--- a/internal/document/links_test.go
+++ b/internal/document/links_test.go
@@ -14,8 +14,26 @@ func TestFindLinks(t *testing.T) {
 		"```mojo\n" +
 		"a [link3] in a code block\n" +
 		"```\n" +
-		"and a normal [link4] again.\n"
+		"and a normal [link4] again.\n" +
+		"and a doc inheritance [[link4]].\n"
 	indices, err := findLinks(text, linkRegex, true)
+	assert.Nil(t, err)
+	assert.NotNil(t, indices)
+	assert.Equal(t, 4, len(indices))
+	assert.Equal(t, "[link1]", text[indices[0]:indices[1]])
+	assert.Equal(t, "[link4]", text[indices[2]:indices[3]])
+}
+
+func TestTranscludesLinks(t *testing.T) {
+	text := "⌘a [[link1]].\n" +
+		"a `[[link2]] in inline` code\n" +
+		"and finally...\n" +
+		"```mojo\n" +
+		"a [[link3]] in a code block\n" +
+		"```\n" +
+		"and a normal [[link4]] again.\n" +
+		"and a doc inheritance [link5].\n"
+	indices, err := findLinks(text, transcludeRegex, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, indices)
 	assert.Equal(t, 4, len(indices))

--- a/internal/document/processor.go
+++ b/internal/document/processor.go
@@ -14,7 +14,7 @@ type Processor struct {
 	Formatter          Formatter
 	Docs               *Docs
 	ExportDocs         *Docs
-	allPaths           map[string]bool         // Full paths of all original members. Used to check whether all re-exports could be found.
+	allPaths           map[string]Named        // Full paths of all original members. Used to check whether all re-exports could be found.
 	linkTargets        map[string]elemPath     // Mapping from full (new) member paths to link strings.
 	linkExports        map[string]string       // Mapping from original to new member paths.
 	linkExportsReverse map[string]*exportError // Used to check for name collisions through re-exports.
@@ -127,15 +127,15 @@ func (proc *Processor) addLinkExport(oldPath, newPath []string) {
 	proc.linkExports[pOld] = pNew
 }
 
-func (proc *Processor) addLinkTarget(elPath, filePath []string, kind string, isSection bool) {
+func (proc *Processor) addLinkTarget(elem Named, elPath, filePath []string, kind string, isSection bool) {
 	proc.linkTargets[strings.Join(elPath, ".")] = elemPath{Elements: filePath, Kind: kind, IsSection: isSection}
 }
 
-func (proc *Processor) addElementPath(elPath, filePath []string, kind string, isSection bool) {
+func (proc *Processor) addElementPath(elem Named, elPath, filePath []string, kind string, isSection bool) {
 	if isSection && kind != "package" && kind != "module" { // actually, we are want to let aliases pass
 		return
 	}
-	proc.allPaths[strings.Join(elPath, ".")] = true
+	proc.allPaths[strings.Join(elPath, ".")] = elem
 	_ = filePath
 }
 

--- a/internal/document/processor.go
+++ b/internal/document/processor.go
@@ -74,6 +74,10 @@ func (proc *Processor) PrepareDocs(subdir string) error {
 		return err
 	}
 
+	if err := proc.processTranscludes(proc.Docs); err != nil {
+		return err
+	}
+
 	if proc.Config.UseExports {
 		proc.renameAll(proc.ExportDocs.Decl)
 	}

--- a/internal/document/render.go
+++ b/internal/document/render.go
@@ -71,14 +71,15 @@ func ExtractTestsMarkdown(config *Config, form Formatter, baseDir string, build 
 func renderWith(config *Config, proc *Processor, subdir string) error {
 	caseSensitiveSystem = !config.CaseInsensitive
 
+	if err := proc.PrepareDocs(subdir); err != nil {
+		return err
+	}
 	var missing []missingDocs
 	var stats missingStats
 	if config.ReportMissing {
 		missing = proc.Docs.Decl.CheckMissing("", &stats)
 	}
-	if err := proc.PrepareDocs(subdir); err != nil {
-		return err
-	}
+
 	outPath := path.Join(config.OutputDir, subdir)
 	if err := renderPackage(proc.ExportDocs.Decl, []string{outPath}, proc); err != nil {
 		return err

--- a/internal/document/transclude.go
+++ b/internal/document/transclude.go
@@ -1,33 +1,157 @@
 package document
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func (proc *Processor) processTranscludes(docs *Docs) error {
-	return proc.walkAllDocStrings(docs, proc.replaceTranscludes, func(elem Named) string {
-		return elem.GetName()
-	})
+	return proc.replaceTranscludesPackage(docs.Decl, []string{})
 }
 
-func (proc *Processor) replaceTranscludes(text string, elems []string, modElems int) (string, error) {
-	indices, err := findLinks(text, transcludeRegex)
+func (proc *Processor) replaceTranscludesPackage(p *Package, elems []string) error {
+	newElems := appendNew(elems, p.Name)
+	for _, pkg := range p.Packages {
+		if err := proc.replaceTranscludesPackage(pkg, newElems); err != nil {
+			return err
+		}
+	}
+	for _, mod := range p.Modules {
+		if err := proc.replaceTranscludesModule(mod, newElems); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (proc *Processor) replaceTranscludesModule(m *Module, elems []string) error {
+	newElems := appendNew(elems, m.Name)
+	for _, s := range m.Structs {
+		structElems := appendNew(newElems, s.Name)
+		for _, f := range s.Functions {
+			if len(f.Overloads) == 0 {
+				if err := proc.replaceTranscludes(f, structElems, len(newElems)); err != nil {
+					return err
+				}
+			} else {
+				for _, o := range f.Overloads {
+					if err := proc.replaceTranscludes(o, structElems, len(newElems)); err != nil {
+						return err
+					}
+				}
+			}
+		}
+
+	}
+	return nil
+}
+
+func (proc *Processor) replaceTranscludes(elem *Function, elems []string, modElems int) error {
+	indices, err := findLinks(elem.Summary, transcludeRegex)
 	if err != nil {
-		return "", err
+		return err
 	}
 	if len(indices) == 0 {
-		return text, nil
+		return nil
 	}
-	for i := len(indices) - 2; i >= 0; i -= 2 {
-		start, end := indices[i], indices[i+1]
-		link := text[start+1 : end-1]
+	if len(indices) > 2 {
+		return fmt.Errorf("multiple doc transclusions in %s", strings.Join(elems, "."))
+	}
+	start, end := indices[0], indices[1]
+	link := elem.Summary[start+1 : end-1]
 
-		content, ok, err := proc.refToPlaceholder(link, elems, modElems)
-		if err != nil {
-			return "", err
-		}
-		if !ok {
+	content, ok, err := proc.refToPlaceholder(link, elems, modElems, false)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	from, ok := proc.allPaths[content]
+	if !ok {
+		return fmt.Errorf("doc transclusions source %s (%s) in %s not found", link, content, strings.Join(elems, "."))
+	}
+	trait, ok := from.(*Trait)
+	if !ok {
+		return fmt.Errorf("doc transclusions source %s (%s) in %s is not a trait", link, content, strings.Join(elems, "."))
+	}
+
+	sourceFunc, ok := findImplementedFunction(elem, trait)
+	if !ok {
+		return fmt.Errorf("no matching doc transclusion found for %s.%s in %s. Required signature: %s", link, elem.Name, strings.Join(elems, "."), elem.Signature)
+	}
+
+	elem.MemberSummary = sourceFunc.MemberSummary
+	elem.Description = sourceFunc.Description
+	elem.ReturnsDoc = sourceFunc.ReturnsDoc
+	elem.RaisesDoc = sourceFunc.RaisesDoc
+
+	for i, arg := range sourceFunc.Args {
+		elem.Args[i].Description = arg.Description
+	}
+	for i, par := range sourceFunc.Parameters {
+		elem.Parameters[i].Description = par.Description
+	}
+
+	return nil
+}
+
+func findImplementedFunction(structFunc *Function, trait *Trait) (*Function, bool) {
+	var sourceFunc *Function
+	for _, f := range trait.Functions {
+		if f.Name != structFunc.Name {
 			continue
 		}
-		text = fmt.Sprintf("%s{%s}%s", text[:start], content, text[end:])
+		if len(f.Overloads) == 0 {
+			if functionsMatch(structFunc, f) {
+				sourceFunc = f
+			}
+			break
+		}
+		for _, o := range f.Overloads {
+			if functionsMatch(structFunc, o) {
+				sourceFunc = o
+			}
+			break
+		}
+		break
 	}
-	return text, nil
+	return sourceFunc, sourceFunc != nil
+}
+
+func functionsMatch(s, t *Function) bool {
+	if len(s.Args) != len(t.Args) {
+		return false
+	}
+	if len(s.Parameters) != len(t.Parameters) {
+		return false
+	}
+
+	for i := range s.Args {
+		argS, argT := s.Args[i], t.Args[i]
+		if argS.Type != argT.Type {
+			if !(argS.Type == "Self" && argT.Type == "_Self") {
+				return false
+			}
+		}
+		if argS.PassingKind != argT.PassingKind {
+			return false
+		}
+		if argS.Convention != argT.Convention {
+			return false
+		}
+	}
+
+	for i := range s.Parameters {
+		parS, parT := s.Parameters[i], t.Parameters[i]
+		if parS.Type != parT.Type {
+			return false
+		}
+		if parS.PassingKind != parT.PassingKind {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/document/transclude.go
+++ b/internal/document/transclude.go
@@ -112,8 +112,8 @@ func findImplementedFunction(structFunc *Function, trait *Trait) (*Function, boo
 		for _, o := range f.Overloads {
 			if functionsMatch(structFunc, o) {
 				sourceFunc = o
+				break
 			}
-			break
 		}
 		break
 	}

--- a/internal/document/transclude.go
+++ b/internal/document/transclude.go
@@ -47,7 +47,7 @@ func (proc *Processor) replaceTranscludesModule(m *Module, elems []string) error
 }
 
 func (proc *Processor) replaceTranscludes(elem *Function, elems []string, modElems int) error {
-	indices, err := findLinks(elem.Summary, transcludeRegex)
+	indices, err := findLinks(elem.Summary, transcludeRegex, false)
 	if err != nil {
 		return err
 	}

--- a/internal/document/transclude.go
+++ b/internal/document/transclude.go
@@ -1,0 +1,33 @@
+package document
+
+import "fmt"
+
+func (proc *Processor) processTranscludes(docs *Docs) error {
+	return proc.walkAllDocStrings(docs, proc.replaceTranscludes, func(elem Named) string {
+		return elem.GetName()
+	})
+}
+
+func (proc *Processor) replaceTranscludes(text string, elems []string, modElems int) (string, error) {
+	indices, err := findLinks(text, transcludeRegex)
+	if err != nil {
+		return "", err
+	}
+	if len(indices) == 0 {
+		return text, nil
+	}
+	for i := len(indices) - 2; i >= 0; i -= 2 {
+		start, end := indices[i], indices[i+1]
+		link := text[start+1 : end-1]
+
+		content, ok, err := proc.refToPlaceholder(link, elems, modElems)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			continue
+		}
+		text = fmt.Sprintf("%s{%s}%s", text[:start], content, text[end:])
+	}
+	return text, nil
+}

--- a/test/ref/test/RenamedStruct-.md
+++ b/test/ref/test/RenamedStruct-.md
@@ -56,4 +56,19 @@ fn struct_method[T: Intable](self, arg: StructParameter) -> Int
 
 Error [`RenamedStruct.struct_method`](RenamedStruct-.md#struct_method).
 
+### `impl_method`
+
+```mojo
+fn impl_method(self, x: Int)
+```
+
+Test method for transclusions.
+
+More details...
+
+**Args:**
+
+- **self** (`Self`)
+- **x** (`Int`): Itself.
+
 

--- a/test/ref/test/Trait-.md
+++ b/test/ref/test/Trait-.md
@@ -39,4 +39,19 @@ fn trait_method[T: Intable](self: _Self, arg: T) -> Int
 
 Error [`RenamedStruct.struct_method`](RenamedStruct-.md#struct_method).
 
+### `impl_method`
+
+```mojo
+fn impl_method(self: _Self, x: Int)
+```
+
+Test method for transclusions.
+
+More details...
+
+**Args:**
+
+- **self** (`_Self`)
+- **x** (`Int`): Itself.
+
 

--- a/test/src/mod.mojo
+++ b/test/src/mod.mojo
@@ -44,7 +44,7 @@ struct Struct[StructParameter: Intable]:
         return self.struct_field
 
     fn impl_method(self, x: Int):
-        """{.Trait}."""
+        """[[.Trait]]."""
         pass
 
 

--- a/test/src/mod.mojo
+++ b/test/src/mod.mojo
@@ -43,6 +43,10 @@ struct Struct[StructParameter: Intable]:
         """
         return self.struct_field
 
+    fn impl_method(self, x: Int):
+        """{.Trait}."""
+        pass
+
 
 trait Trait:
     """[.ModuleAlias].
@@ -68,6 +72,16 @@ trait Trait:
 
         Raises:
             Error [.Struct.struct_method].
+        """
+        ...
+
+    fn impl_method(self, x: Int):
+        """Test method for transclusions.
+
+        More details...
+
+        Args:
+          x: Itself.
         """
         ...
 


### PR DESCRIPTION
Allows to transclude method docs from a trait into a struct method:

```mojo
trait MyTrait:
    fn do_something(self) -> Int:
        """
        A method that returns an integer.

        Returns:
            An arbitrary integer.
        """
        ...

@value
struct MyStruct(MyTrait):
    fn do_something(self) -> Int:
        """See [[.MyTrait]]."""
        return 100
```

The signature of the method must be the same as in the trait. So aliases can't be used if the trait does not use them.

Fixes #207