### PR TITLE
Don't warn on missing docs for `self` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Adds address sanitizer and debug warnings to tests bash script (#231)
 * Doesn't warn on missing return docs for `__init__`, `__moveinit__` and `__copyinit__` (#232)
+* Doesn't warn on missing docs for any `self` arguments, irrespective of the type (#233)
 
 ## [[v0.11.2]](https://github.com/mlange-42/modo/compare/v0.11.1...v0.11.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [[unpublished]](https://github.com/mlange-42/modo/compare/v0.11.2...main)
+## [[v0.11.3]](https://github.com/mlange-42/modo/compare/v0.11.2...v0.11.3)
 
 ### Other
 

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -265,7 +265,7 @@ type Arg struct {
 }
 
 func (a *Arg) checkMissing(path string, stats *missingStats) (missing []missingDocs) {
-	if a.Name == "self" && (a.Type == "Self" || a.Type == "_Self") {
+	if a.Name == "self" {
 		return nil
 	}
 	if a.Convention == "out" {


### PR DESCRIPTION
Fixes #229 